### PR TITLE
OB-4895: Permit topic groups and fix with eager fetch

### DIFF
--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/model/TopicEntity.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/model/TopicEntity.java
@@ -54,6 +54,6 @@ public class TopicEntity implements TenantAware {
   @Column(name = "update_date")
   private LocalDateTime updateDate;
 
-  @ManyToMany(mappedBy = "topicEntities")
+  @ManyToMany(mappedBy = "topicEntities", fetch = FetchType.EAGER)
   Set<TopicGroupEntity> topicGroupEntities;
 }

--- a/src/main/java/de/caritas/cob/consultingtypeservice/config/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/config/SecurityConfig.java
@@ -89,6 +89,8 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .permitAll()
         .requestMatchers(new NegatedRequestMatcher(new AntPathRequestMatcher("/topic/*")))
         .permitAll()
+        .requestMatchers(new NegatedRequestMatcher(new AntPathRequestMatcher("/topic-groups")))
+        .permitAll()
         .requestMatchers(new NegatedRequestMatcher(new AntPathRequestMatcher("/topicadmin")))
         .permitAll()
         .requestMatchers(new NegatedRequestMatcher(new AntPathRequestMatcher("/topicadmin/*")))


### PR DESCRIPTION
@tkuzynow We got this thingy:

```
2023-06-06 12:35:15.661  WARN 1 --- [nio-8080-exec-1] o.s.web.servlet.PageNotFound             : Request method 'GET' not supported
2023-06-06 12:36:01.767  WARN 1 --- [nio-8080-exec-2] o.s.web.servlet.PageNotFound             : Request method 'GET' not supported
2023-06-06 12:36:03.774  WARN 1 --- [nio-8080-exec-3] o.s.web.servlet.PageNotFound             : Request method 'GET' not supported
2023-06-06 12:36:14.511  WARN 1 --- [nio-8080-exec-4] o.s.web.servlet.PageNotFound             : Request method 'GET' not supported
2023-06-06 12:37:52.118  WARN 1 --- [nio-8080-exec-6] o.s.web.servlet.PageNotFound             : Request method 'GET' not supported
2023-06-06 12:41:15.007  WARN 1 --- [nio-8080-exec-1] o.s.web.servlet.PageNotFound             : Request method 'GET' not supported
2023-06-06 12:45:20.843  INFO 1 --- [io-8080-exec-10] o.keycloak.adapters.KeycloakDeployment   : Loaded URLs from https://dev.diakonie.dev.virtual-identity.com/auth/realms/online-beratung/.well-known/openid-configuration
2023-06-06 12:45:21.088 ERROR 1 --- [io-8080-exec-10] d.c.c.c.api.service.LogService           : ConsultingTypeService API: 500 Internal Server Error: org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: de.caritas.cob.consultingtypeservice.api.model.TopicGroupEntity.topicEntities, could not initialize proxy - no Session
	at org.hibernate.collection.internal.AbstractPersistentCollection.throwLazyInitializationException(AbstractPersistentCollection.java:606)
	at org.hibernate.collection.internal.AbstractPersistentCollection.withTemporarySessionIfNeeded(AbstractPersistentCollection.java:218)
	at org.hibernate.collection.internal.AbstractPersistentCollection.initialize(AbstractPersistentCollection.java:585)
	at org.hibernate.collection.internal.AbstractPersistentCollection.read(AbstractPersistentCollection.java:149)
	at org.hibernate.collection.internal.PersistentSet.iterator(PersistentSet.java:188)
	at java.base/java.util.Spliterators$IteratorSpliterator.estimateSize(Spliterators.java:1821)
	at java.base/java.util.Spliterator.getExactSizeIfKnown(Spliterator.java:408)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:483)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at de.caritas.cob.consultingtypeservice.api.converter.TopicGroupConverter.topicIdsOf(TopicGroupConverter.java:34)
	at de.caritas.cob.consultingtypeservice.api.converter.TopicGroupConverter.lambda$itemsOf$0(TopicGroupConverter.java:25)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at de.caritas.cob.consultingtypeservice.api.converter.TopicGroupConverter.itemsOf(TopicGroupConverter.java:28)
	at de.caritas.cob.consultingtypeservice.api.converter.TopicGroupConverter.toTopicGroupsDTO(TopicGroupConverter.java:16)
	at de.caritas.cob.consultingtypeservice.api.controller.TopicGroupsController.getAllTopicGroups(TopicGroupsController.java:26)
	at de.caritas.cob.consultingtypeservice.api.controller.TopicGroupsController$$FastClassBySpringCGLIB$$2eb3232c.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at org.springframework.validation.beanvalidation.MethodValidationInterceptor.invoke(MethodValidationInterceptor.java:123)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708)
	at de.caritas.cob.consultingtypeservice.api.controller.TopicGroupsController$$EnhancerBySpringCGLIB$$f5e7b4c0.getAllTopicGroups(<generated>)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1067)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:963)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:655)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:764)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.keycloak.adapters.springsecurity.filter.KeycloakAuthenticatedActionsFilter.doFilter(KeycloakAuthenticatedActionsFilter.java:74)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
```